### PR TITLE
Foot UI issue in Mobile

### DIFF
--- a/src/components/app/AppFooter.vue
+++ b/src/components/app/AppFooter.vue
@@ -5,13 +5,25 @@
         {{ $t('footer.resumeSpy') }}&nbsp;<span class="gold">©</span>&nbsp;{{ new Date().getFullYear() }}
       </span>
 
+      <!-- Desktop: full "Buy me a coffee" button -->
       <a
         href="https://www.buymeacoffee.com/feifeijin"
         target="_blank"
         rel="noopener"
-        class="footer-coffee"
+        class="footer-coffee footer-coffee-desktop"
       >
         {{ $t('footer.buyMeCoffee') }}
+      </a>
+
+      <!-- Mobile: icon-only coffee link -->
+      <a
+        href="https://www.buymeacoffee.com/feifeijin"
+        target="_blank"
+        rel="noopener"
+        class="footer-coffee footer-coffee-mobile"
+        :title="$t('footer.buyMeCoffee')"
+      >
+        ☕
       </a>
 
       <span class="footer-right">{{ $t('footer.author') }}</span>
@@ -54,13 +66,43 @@
   letter-spacing: 0.08em;
   color: #888888;
   text-decoration: none;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.footer-coffee-desktop {
   border: 1px solid #D4D4D4;
   padding: 0.4rem 1rem;
-  transition: color 0.2s, border-color 0.2s;
+}
+
+.footer-coffee-mobile {
+  display: none;
+  font-size: 1rem;
+  line-height: 1;
 }
 
 .footer-coffee:hover {
   color: #121212;
   border-color: #888888;
+}
+
+@media (max-width: 640px) {
+  .footer-inner {
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+  }
+
+  .footer-left,
+  .footer-right {
+    font-size: 0.65rem;
+    letter-spacing: 0.05em;
+  }
+
+  .footer-coffee-desktop {
+    display: none;
+  }
+
+  .footer-coffee-mobile {
+    display: inline;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- On mobile screens (≤640 px), the "Buy me a coffee" text button is replaced with a compact ☕ icon-only link so the footer fits in a single row
- `flex-wrap: nowrap` is applied at the mobile breakpoint to prevent the footer items from stacking
- Font size and letter-spacing are slightly reduced on mobile to keep the copyright and author text from overflowing

## Test plan
- [ ] Open the site on a mobile viewport (≤640 px) and scroll to the bottom — footer should be one row
- [ ] Confirm the ☕ icon links to https://www.buymeacoffee.com/feifeijin
- [ ] On desktop (>640 px) the full "☕ Buy me a coffee" button with border still shows
- [ ] All 59 unit tests pass (`npm run test:unit`)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)