### PR TITLE
Can not switch languages in mobile website

### DIFF
--- a/Frontend/tests/components/AppBar.spec.ts
+++ b/Frontend/tests/components/AppBar.spec.ts
@@ -100,6 +100,23 @@ describe('AppBar', () => {
       },
     })
 
+  const mobileFactory = () =>
+    shallowMount(AppBar, {
+      global: {
+        mocks: {
+          $vuetify: {
+            display: {
+              mdAndUp: false,
+              smAndDown: true,
+            },
+          },
+        },
+        stubs: {
+          ...commonVuetifyStubs,
+        },
+      },
+    })
+
   it('opens GitHub link in new tab when GitHub menu item is clicked', async () => {
     // Purpose: validate external navigation branch inside menu handler.
     const wrapper = factory()
@@ -125,6 +142,19 @@ describe('AppBar', () => {
   it('calls changeLanguage helper when a language option is selected', async () => {
     // Purpose: ensure language selection delegates through i18n helper.
     const wrapper = factory()
+    const languageButton = wrapper
+      .findAll('[role="button"]')
+      .find((btn) => btn.text().includes('中文'))
+
+    expect(languageButton).toBeDefined()
+    await languageButton!.trigger('click')
+
+    expect(setLanguageMock).toHaveBeenCalledWith('zh')
+  })
+
+  it('shows language switcher in mobile drawer and calls changeLanguage on selection', async () => {
+    // Purpose: verify the mobile drawer exposes the same language-switch capability as the desktop bar.
+    const wrapper = mobileFactory()
     const languageButton = wrapper
       .findAll('[role="button"]')
       .find((btn) => btn.text().includes('中文'))

--- a/src/components/app/AppBar.vue
+++ b/src/components/app/AppBar.vue
@@ -6,6 +6,27 @@
         {{ item.name }}
       </v-list-item>
       <v-divider class="my-2" />
+      <!-- Language switcher for mobile -->
+      <v-menu offset-y>
+        <template #activator="{ props }">
+          <v-list-item v-bind="props">
+            <template #prepend>
+              <v-icon>mdi-translate</v-icon>
+            </template>
+            {{ currentLanguage }}
+          </v-list-item>
+        </template>
+        <v-list>
+          <v-list-item
+            v-for="language in languages"
+            :key="language.code"
+            @click="changeLanguage(language.code)"
+          >
+            {{ language.name }}
+          </v-list-item>
+        </v-list>
+      </v-menu>
+      <v-divider class="my-2" />
       <v-list-item v-if="isAuthenticated" @click="handleLogout">
         <v-icon>mdi-logout</v-icon>
         {{ t('navigation.logout') }}


### PR DESCRIPTION
## Summary

- Add a language switcher entry to the mobile navigation drawer (`v-navigation-drawer`) in `AppBar.vue`, matching the existing desktop behaviour
- The switcher uses a `v-menu` activator on a `v-list-item` with a `mdi-translate` icon and shows all supported locales from `useLanguageSwitch`
- Add a `mobileFactory` helper and a dedicated unit test that verifies language selection works from the mobile drawer

## Test plan

- [x] All 60 existing unit tests pass (`npx vitest run`)
- [x] New test: `shows language switcher in mobile drawer and calls changeLanguage on selection`
- [ ] Manual: open site on a mobile viewport, tap the hamburger menu — the language switcher should appear between the nav links and the sign-in/out button

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)