### PR TITLE
UI What lies in adjustment.

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -474,23 +474,24 @@ const features = [
 }
 
 .card-header {
-  display: contents;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
 }
 
 .card-num {
-  display: block;
   font-family: var(--f-title);
   font-size: 0.65rem;
   color: var(--gold-dim);
   letter-spacing: 0.35em;
-  margin-bottom: 0.75rem;
+  flex-shrink: 0;
 }
 
 .card-icon {
-  display: block;
   font-size: 1.4rem;
   color: var(--gold);
-  margin-bottom: 1rem;
+  flex-shrink: 0;
 }
 
 .card-title {
@@ -499,25 +500,7 @@ const features = [
   font-weight: 700;
   color: var(--text);
   letter-spacing: 0.12em;
-  margin: 0 0 0.85rem;
-}
-
-@media (max-width: 600px) {
-  .card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.85rem;
-  }
-
-  .card-header .card-num,
-  .card-header .card-icon {
-    margin-bottom: 0;
-  }
-
-  .card-header .card-title {
-    margin: 0;
-  }
+  margin: 0;
 }
 
 .card-desc {


### PR DESCRIPTION
Closes #44

## Summary
- `.card-header` was using `display: contents` in web mode, causing `card-num`, `card-icon`, and `card-title` to stack vertically (each as block elements).
- Mobile (≤600px) already had a media query applying `display: flex` to put them on one line.
- Fixed by promoting the flex layout to the base `.card-header` style so it applies at **all** screen sizes, and removed the now-redundant mobile-only override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)