### PR TITLE
UI What lies in adjustment.

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -474,23 +474,24 @@ const features = [
 }
 
 .card-header {
-  display: contents;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
 }
 
 .card-num {
-  display: block;
   font-family: var(--f-title);
   font-size: 0.65rem;
   color: var(--gold-dim);
   letter-spacing: 0.35em;
-  margin-bottom: 0.75rem;
+  flex-shrink: 0;
 }
 
 .card-icon {
-  display: block;
   font-size: 1.4rem;
   color: var(--gold);
-  margin-bottom: 1rem;
+  flex-shrink: 0;
 }
 
 .card-title {
@@ -499,25 +500,7 @@ const features = [
   font-weight: 700;
   color: var(--text);
   letter-spacing: 0.12em;
-  margin: 0 0 0.85rem;
-}
-
-@media (max-width: 600px) {
-  .card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.85rem;
-  }
-
-  .card-header .card-num,
-  .card-header .card-icon {
-    margin-bottom: 0;
-  }
-
-  .card-header .card-title {
-    margin: 0;
-  }
+  margin: 0;
 }
 
 .card-desc {


### PR DESCRIPTION
## Summary
- Fix `.card-header` to use `display: flex` for all screen sizes (was `display: contents` on desktop, only flex on mobile ≤600px)
- Remove the now-redundant `@media (max-width: 600px)` override for `.card-header`
- Remove individual `margin-bottom` from `.card-num` and `.card-icon` (spacing now handled by the flex container's `margin-bottom`)
- Keep `flex-shrink: 0` on `.card-num` and `.card-icon` so they never squish on narrow cards

## Test plan
- [ ] Open the home page on a wide desktop viewport — verify card-num, card-icon, and card-title appear on one line
- [ ] Verify mobile (≤600px) still looks correct
- [ ] Verify card layout / description text is unaffected

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)