### PR TITLE
BUG：When I set any of resume detail as default, when I open resume, it should show the default one

### DIFF
--- a/src/views/CreateView.vue
+++ b/src/views/CreateView.vue
@@ -597,6 +597,9 @@ const loadResumeDetails = async (resumeId: string) => {
       editors.value = resumeDetails.value.map((detail) => detail.content)
       savedContent.value = resumeDetails.value.map((detail) => detail.content)
       saveStatus.value = 'idle'
+      // Set the active tab to the default resume detail if one exists
+      const defaultIndex = resumeDetails.value.findIndex((detail) => detail.isDefault)
+      activeTab.value = defaultIndex !== -1 ? defaultIndex : 0
       // Seed lastSyncedContent so an unmodified resume blocks unnecessary syncs
       resumeDetails.value.forEach((detail) => {
         if (detail.id) lastSyncedContent.value[detail.id] = detail.content


### PR DESCRIPTION
Closes #47

## Summary
- In `loadResumeDetails()` inside `CreateView.vue`, after the resume details are fetched, find the index of the detail where `isDefault === true` and set `activeTab` to that index
- Falls back to `0` if no default is set, preserving existing behaviour

## Test plan
- [ ] Open a resume with multiple details
- [ ] Set the last detail as default
- [ ] Navigate back to MySpyPage and re-open the resume
- [ ] Verify the editor opens on the default tab, not the first tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)