### PR TITLE
BUG: In myspy page, when I import an resume , we shall allow user import md file.

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -191,7 +191,7 @@
     "importing": "Analysing…",
     "importError": "Failed to import file. Please try again.",
     "importSuccess": "Resume imported successfully.",
-    "importHint": "PDF, DOCX or TXT · max 10 MB"
+    "importHint": "PDF, DOCX, TXT or MD · max 10 MB"
   },
   "languages": {
     "english": "English",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -191,7 +191,7 @@
     "importing": "解析中…",
     "importError": "ファイルのインポートに失敗しました。もう一度お試しください。",
     "importSuccess": "職務経歴書を正常にインポートしました。",
-    "importHint": "PDF・DOCX・TXT · 最大10MB"
+    "importHint": "PDF・DOCX・TXT・MD · 最大10MB"
   },
   "languages": {
     "english": "英語",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -191,7 +191,7 @@
     "importing": "正在解析…",
     "importError": "文件导入失败，请重试。",
     "importSuccess": "简历导入成功。",
-    "importHint": "PDF、DOCX 或 TXT · 最大 10 MB"
+    "importHint": "PDF、DOCX、TXT 或 MD · 最大 10 MB"
   },
   "languages": {
     "english": "英语",

--- a/src/views/MySpyView.vue
+++ b/src/views/MySpyView.vue
@@ -18,7 +18,7 @@
           <input
             ref="fileInputRef"
             type="file"
-            accept=".pdf,.docx,.doc,.txt"
+            accept=".pdf,.docx,.doc,.txt,.md"
             class="sr-only"
             @change="onFileSelected"
           />
@@ -107,7 +107,7 @@
           </svg>
           <p class="drop-label">↑ {{ $t('mySpyView.empty.dropLabel') }}</p>
           <p class="drop-hint">{{ $t('mySpyView.empty.dropHint') }}</p>
-          <p class="drop-formats">PDF · DOCX · TXT</p>
+          <p class="drop-formats">PDF · DOCX · TXT · MD</p>
         </template>
       </div>
 


### PR DESCRIPTION
Closes #50

## Summary
- Added `.md` to the file input `accept` attribute so the browser's file picker allows selecting Markdown files
- Updated the drop-zone format label from `PDF · DOCX · TXT` to `PDF · DOCX · TXT · MD`
- Updated `importHint` locale strings (EN / JA / ZH) to include MD for consistency

## Test plan
- [ ] Open the MySpy page (no resumes) and click the drop zone — verify the file picker now shows `.md` files alongside PDF/DOCX/TXT
- [ ] Drag-and-drop a `.md` resume file onto the drop zone — verify it imports successfully
- [ ] Use the header "Import File" button and select a `.md` file — verify it imports successfully
- [ ] Confirm the format badge in the drop zone reads `PDF · DOCX · TXT · MD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)