### PR TITLE
fix: render Privacy and Commercial Transactions pages (vue-i18n @ escape)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,8 @@ import GlobalLoadingOverlay from './components/GlobalLoadingOverlay.vue'
 import GlobalToastContainer from './components/GlobalToastContainer.vue'
 
 const route = useRoute()
+
+const hideFooterRoutes = new Set(['create', 'privacy', 'terms', 'commercial-transactions'])
 </script>
 
 <template>
@@ -16,7 +18,7 @@ const route = useRoute()
       <GuestSessionBanner />
       <router-view />
     </v-main>
-    <app-footer v-if="route.name !== 'create'" />
+    <app-footer v-if="!hideFooterRoutes.has(route.name as string)" />
 
     <!-- Global Loading Overlay -->
     <GlobalLoadingOverlay />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -306,7 +306,7 @@
       },
       "contact": {
         "heading": "Contact",
-        "body": "For any privacy-related questions or data deletion requests, please contact us at feifeijinjp@gmail.com."
+        "body": "For any privacy-related questions or data deletion requests, please contact us at feifeijinjp{'@'}gmail.com."
       }
     },
     "terms": {
@@ -348,7 +348,7 @@
       "items": {
         "businessName": { "label": "Business Name", "value": "ResumeSpy" },
         "operator": { "label": "Operator", "value": "Fei-Fei Jin" },
-        "email": { "label": "Contact Email", "value": "feifeijinjp@gmail.com" },
+        "email": { "label": "Contact Email", "value": "feifeijinjp{'@'}gmail.com" },
         "address": { "label": "Address", "value": "Available upon request without delay." },
         "service": { "label": "Service Description", "value": "AI-powered resume management platform providing resume editing, version control, multi-language support, and AI-powered tailoring." },
         "pricing": { "label": "Pricing", "value": "Currently free of charge. Pricing for any future premium features will be clearly disclosed before purchase." },

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -306,7 +306,7 @@
       },
       "contact": {
         "heading": "お問い合わせ",
-        "body": "プライバシーに関するご質問やデータ削除のご依頼は、feifeijinjp@gmail.com までご連絡ください。"
+        "body": "プライバシーに関するご質問やデータ削除のご依頼は、feifeijinjp{'@'}gmail.com までご連絡ください。"
       }
     },
     "terms": {
@@ -348,7 +348,7 @@
       "items": {
         "businessName": { "label": "事業者名", "value": "ResumeSpy" },
         "operator": { "label": "運営責任者", "value": "金 菲菲（Fei-Fei Jin）" },
-        "email": { "label": "お問い合わせ先メールアドレス", "value": "feifeijinjp@gmail.com" },
+        "email": { "label": "お問い合わせ先メールアドレス", "value": "feifeijinjp{'@'}gmail.com" },
         "address": { "label": "所在地", "value": "請求があった場合は遅滞なく開示いたします" },
         "service": { "label": "サービス内容", "value": "職務経歴書の編集・バージョン管理・多言語対応・AI 最適化を提供する AI 活用型職務経歴書管理プラットフォーム" },
         "pricing": { "label": "販売価格", "value": "現在は無料でご利用いただけます。有料機能を導入する場合は、購入前に料金を明示いたします。" },

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -297,7 +297,7 @@
       },
       "contact": {
         "heading": "联系方式",
-        "body": "如有任何隐私相关问题或数据删除请求，请发送邮件至 feifeijinjp@gmail.com 联系我们。"
+        "body": "如有任何隐私相关问题或数据删除请求，请发送邮件至 feifeijinjp{'@'}gmail.com 联系我们。"
       }
     },
     "terms": {
@@ -339,7 +339,7 @@
       "items": {
         "businessName": { "label": "商号", "value": "ResumeSpy" },
         "operator": { "label": "运营负责人", "value": "金菲菲（Fei-Fei Jin）" },
-        "email": { "label": "联系邮箱", "value": "feifeijinjp@gmail.com" },
+        "email": { "label": "联系邮箱", "value": "feifeijinjp{'@'}gmail.com" },
         "address": { "label": "所在地址", "value": "应请求可无延迟地披露。" },
         "service": { "label": "服务内容", "value": "提供简历编辑、版本控制、多语言支持和 AI 优化功能的 AI 驱动简历管理平台。" },
         "pricing": { "label": "价格", "value": "目前免费使用。如推出付费功能，将在购买前明确披露价格。" },


### PR DESCRIPTION
Follow-up to #55. PR #55 was merged but the Privacy and Commercial Transactions pages are still blank in production. This patch is the actual root-cause fix.

## Summary

- **Bug:** vue-i18n 9 parses `@` in message strings as the "linked message" syntax (`@:foo`). The literal `feifeijinjp@gmail.com` in `legal.privacy.contact.body` and `legal.commercial.items.email.value` threw `SyntaxError: Invalid linked format` at render time, which Vue caught silently — Privacy and Commercial rendered as blank pages. Terms has no `@`, so it kept working.
- **Fix:** Escape `@` with vue-i18n's literal interpolation `{'@'}` in the two affected keys across all three locales (en / ja / zh). The rendered output is still `feifeijinjp@gmail.com`.
- **Footer UI:** Hide the global `AppFooter` on the three legal routes (`/privacy`, `/terms`, `/commercial-transactions`). Each legal page is now self-contained (back-link at top + content), matching the existing pattern that hides the footer on `/create`.

## Verification

- Reproduced the original blank pages on the merged `master` build (Cypress headless, captured DOM + console).
- Console showed `SyntaxError: Invalid linked format` only on Privacy and Commercial — confirming the `@` was the trigger.
- After the fix, the same Cypress run shows the `.noir-legal-wrap` content rendering on all three pages, with `feifeijinjp@gmail.com` visible.
- `npm run build` succeeds.
- `vitest run` — 60/60 unit tests pass.

## Test plan

- [ ] Visit `/privacy` — page renders, content visible, email shown as `feifeijinjp@gmail.com`.
- [ ] Visit `/commercial-transactions` — page renders, table visible, email shown as `feifeijinjp@gmail.com`.
- [ ] Visit `/terms` — still renders.
- [ ] Global footer no longer appears on any of the three legal pages.
- [ ] Global footer still appears on `/`, `/myspy`, etc.
- [ ] Switch UI language to 日本語 / 简体中文 — all three legal pages still render and emails still display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)