### PR TITLE
BUG: It failed when I open a Resume, please check what happend and fix it

### DIFF
--- a/src/api/resume-detail-api.ts
+++ b/src/api/resume-detail-api.ts
@@ -6,7 +6,14 @@ class ResumeDetailService {
   // Fetch resume details by resume ID
   async fetchResumeDetailsByResumeId(resumeId: string): Promise<ResumeDetail[]> {
     try {
-      const response = await axios.get(`${API_BASE_URL}/resumeDetail?resumeId=${resumeId}`)
+      const response = await axios.get(`${API_BASE_URL}/resumeDetail`, {
+        params: { resumeId },
+      })
+      // Defend against unexpected shapes (null, error envelopes, etc.) so a
+      // bad response doesn't throw a TypeError downstream.
+      if (!Array.isArray(response.data)) {
+        return []
+      }
       return response.data.map((item: ResumeDetail) => ({
         id: item.id,
         resumeId: item.resumeId,

--- a/src/views/CreateView.vue
+++ b/src/views/CreateView.vue
@@ -608,7 +608,10 @@ const isAddDisabled = computed(() => {
 
 // Pass overlay: false when refreshing after a quick local action (the caller's local
 // busy flag already provides feedback) so the global overlay doesn't flash.
-const loadResumeDetails = async (resumeId: string, { overlay = true }: { overlay?: boolean } = {}) => {
+const loadResumeDetails = async (
+  resumeId: string,
+  { overlay = true }: { overlay?: boolean } = {},
+) => {
   currentResumeId.value = resumeId
   const fetchDetails = async () => {
     resumeDetails.value = await resumeDetailService.fetchResumeDetailsByResumeId(resumeId)
@@ -632,27 +635,40 @@ const loadResumeDetails = async (resumeId: string, { overlay = true }: { overlay
   await withLoading(fetchDetails, { id: 'load-resume-details', message: commonMessages.loading })
 }
 
+const initBlankResume = () => {
+  const newResumeTitle = t('createView.newResume')
+  tabs.value = [newResumeTitle]
+  editors.value = ['']
+  savedContent.value = ['']
+  resumeDetails.value = [
+    {
+      id: '',
+      resumeId: '',
+      name: newResumeTitle,
+      language: '',
+      content: '',
+      isDefault: true,
+      createTime: '',
+      lastModifyTime: '',
+    },
+  ]
+  activeTab.value = 0
+  currentResumeId.value = null
+}
+
 onMounted(() => {
   const resumeId = route.query.resumeId
   if (typeof resumeId === 'string' && resumeId) {
-    loadResumeDetails(resumeId)
+    // withLoading already toasts on failure; swallow the rejection here so it
+    // doesn't bubble to the global error boundary and replace the page with
+    // the "Something went sideways" view. Fall back to a blank editor so the
+    // user can still work.
+    loadResumeDetails(resumeId).catch((err) => {
+      console.error('[CreateView] Failed to load resume details', err)
+      initBlankResume()
+    })
   } else {
-    const newResumeTitle = t('createView.newResume')
-    tabs.value = [newResumeTitle]
-    editors.value = ['']
-    savedContent.value = ['']
-    resumeDetails.value = [
-      {
-        id: '',
-        resumeId: '',
-        name: newResumeTitle,
-        language: '',
-        content: '',
-        isDefault: true,
-        createTime: '',
-        lastModifyTime: '',
-      },
-    ]
+    initBlankResume()
   }
 
   nextTick(() => {


### PR DESCRIPTION
Closes #74

## Summary
- Opening a resume via `/create?resumeId=X` would replace the page with the "Something went sideways" error view when the resume-details fetch failed for any reason (network blip, unexpected payload, etc.). The toast from `withLoading` already told the user something went wrong, but the unawaited rejection in `onMounted` escaped the component and the global error boundary swapped CreateView for `AppErrorView`.
- The CreateView's first call to `loadResumeDetails` now `.catch()`es the rejection, logs it, and falls back to a blank editor (extracted as `initBlankResume`) so the user can keep working instead of being parked on an error page.
- Hardened `fetchResumeDetailsByResumeId` against non-array responses (null, error envelopes) so a malformed payload no longer throws a TypeError on `.map()`. Also moved the query string to axios `params` for cleaner encoding.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit`
- [ ] Manual: open a valid resume from `/myspy` — editor loads as before.
- [ ] Manual: force the resume-details call to fail (offline / bad id) — a toast appears and the page falls back to a blank editor instead of "Something went sideways".

🤖 Generated with [Claude Code](https://claude.com/claude-code)