### PR TITLE
BUG: It failed when I open a Resume, please check what happend and fix it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "diff": "^8.0.4",
         "dompurify": "^3.4.7",
         "driver.js": "^1.4.0",
+        "highlight.js": "^11.11.1",
         "pinia": "^2.3.1",
         "vue": "^3.5.13",
         "vue-country-flag-next": "^2.3.2",
@@ -1681,6 +1682,15 @@
       "peerDependencies": {
         "@vue/compiler-sfc": "^3.0.0",
         "vue": "^3.0.0"
+      }
+    },
+    "node_modules/@kangc/v-md-editor/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@mdi/font": {
@@ -7188,12 +7198,12 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hookable": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "diff": "^8.0.4",
     "dompurify": "^3.4.7",
     "driver.js": "^1.4.0",
+    "highlight.js": "^11.11.1",
     "pinia": "^2.3.1",
     "vue": "^3.5.13",
     "vue-country-flag-next": "^2.3.2",

--- a/src/plugins/v-md-editor.ts
+++ b/src/plugins/v-md-editor.ts
@@ -5,6 +5,13 @@ import githubTheme from '@kangc/v-md-editor/lib/theme/github.js'
 import '@kangc/v-md-editor/lib/theme/style/github.css'
 import enUS from '@kangc/v-md-editor/lib/lang/en-US'
 
+// Syntax highlighting for fenced code blocks. The github theme calls
+// Hljs.getLanguage() / Hljs.highlight() at render time; without an Hljs
+// instance, any fenced code block with a language identifier crashes the
+// preview with "can't access property 'getLanguage', Hljs is undefined".
+import hljs from 'highlight.js/lib/common'
+import 'highlight.js/styles/github.css'
+
 // Resources for the codemirror editor
 import Codemirror from 'codemirror'
 // mode
@@ -29,9 +36,8 @@ import 'codemirror/lib/codemirror.css'
 
 VMdEditor.lang.use('en-US', enUS)
 VMdEditor.Codemirror = Codemirror
-VMdEditor.use(githubTheme)
-VMdEditor.Codemirror = Codemirror
-VMdEditor.use(githubTheme)
+VMdEditor.use(githubTheme, { Hljs: hljs })
+
 export function registerMarkdownEditor(app: App) {
   app.use(VMdEditor)
 }


### PR DESCRIPTION
Closes #76

## Summary
- The v-md-editor github theme requires an `Hljs` instance to render fenced code blocks. The previous registration passed no options, so `hasLang()` called `Hljs.getLanguage(lang)` on `undefined` and threw `TypeError: can't access property "getLanguage", c is undefined` — which is exactly what crashed the reported resume (its content has a fenced code block with a language tag).
- Register `highlight.js` (`/lib/common` to keep the bundle reasonable) as the `Hljs` option when calling `VMdEditor.use(githubTheme, { Hljs: hljs })`, and pull in the matching `highlight.js/styles/github.css` stylesheet. Also dropped a duplicated `VMdEditor.Codemirror = Codemirror` / `VMdEditor.use(githubTheme)` pair that was left over in the plugin file.

## Test plan
- [x] `npm run type-check` passes
- [x] `npx eslint src/plugins/v-md-editor.ts --max-warnings=0` is clean
- [x] `npm run test:unit -- --run` — 60 tests pass
- [x] `npm run build-only` produces a clean production bundle
- [ ] On the Vercel preview, open the failing resume (`/create?resumeId=caf6625d-d810-4a65-910b-5c789d0c1563`) and confirm the editor + preview load without hitting the ErrorBoundary, and that fenced code blocks render with syntax highlighting.